### PR TITLE
Eliminate usage of ObjectSpace._id2ref

### DIFF
--- a/lib/rr/injections/method_missing_injection.rb
+++ b/lib/rr/injections/method_missing_injection.rb
@@ -51,11 +51,16 @@ module RR
       end
 
       protected
+      BoundObjects = {}
+
       def bind_method
-        subject_class_object_id = subject_class.object_id
+        id = BoundObjects.size
+        BoundObjects[id] = subject_class
+
         subject_class.class_eval((<<-METHOD), __FILE__, __LINE__ + 1)
         def method_missing(method_name, *args, &block)
-          MethodDispatches::MethodMissingDispatch.new(self, ObjectSpace._id2ref(#{subject_class_object_id}), method_name, args, block).call
+          obj = ::RR::Injections::MethodMissingInjection::BoundObjects[#{id}]
+          MethodDispatches::MethodMissingDispatch.new(self, obj, method_name, args, block).call
         end
         METHOD
       end


### PR DESCRIPTION
Two reasons not to use _id2ref:
1) It's slow on other ruby implementations
2) It introduces a hidden bug because _id2ref can return any random
   future object since object ids are recycled
