### PR TITLE
have_received matchers for Rspec2 (fix issue #45)

### DIFF
--- a/lib/rr/adapters/rspec2.rb
+++ b/lib/rr/adapters/rspec2.rb
@@ -1,0 +1,22 @@
+module RR
+  module Adapters
+    module RSpec2
+
+      include RRMethods
+
+      def setup_mocks_for_rspec
+        RR.reset
+      end
+      def verify_mocks_for_rspec
+        RR.verify
+      end
+      def teardown_mocks_for_rspec
+        RR.reset
+      end
+
+      def have_received(method = nil)
+        RR::Adapters::Rspec::InvocationMatcher.new(method)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added an rspec2 adapter, as suggested by @wjbuys in the discussion of issue #45.
