### PR TITLE
in the MiniTest adapter, raise a MiniTest::Assertion

### DIFF
--- a/lib/rr/adapters/minitest.rb
+++ b/lib/rr/adapters/minitest.rb
@@ -16,6 +16,11 @@ module RR
             alias_method :teardown_without_rr, :teardown
             def teardown_with_rr
               RR.verify
+            rescue RR::Errors::RRError => rr_error
+              assertion = ::MiniTest::Assertion.new(rr_error.message)
+              assertion.set_backtrace(rr_error.backtrace)
+              raise assertion
+            ensure
               teardown_without_rr
             end
             alias_method :teardown, :teardown_with_rr

--- a/spec/rr/minitest/minitest_integration_test.rb
+++ b/spec/rr/minitest/minitest_integration_test.rb
@@ -42,7 +42,7 @@ class MiniTestIntegrationTest < MiniTest::Unit::TestCase
 
   def test_times_called_verification
     mock(@subject).foobar(1, 2) {:baz}
-    assert_raises RR::Errors::TimesCalledError do
+    assert_raises MiniTest::Assertion do
       teardown
     end
   end


### PR DESCRIPTION
This allows mock failures to accurately report errors, rather than complaining about uncaught exceptions.
