### PR TITLE
#any_instance_of is being redefined

### DIFF
--- a/lib/rr/adapters/rr_methods.rb
+++ b/lib/rr/adapters/rr_methods.rb
@@ -31,7 +31,6 @@ module RR
         double_definition_create = DoubleDefinitions::DoubleDefinitionCreate.new
         double_definition_create.instance_of(subject, method_name, &definition_eval_block)
       end
-      alias_method :any_instance_of, :instance_of
       alias_method :all_instances_of, :instance_of
 
       # Verifies all the DoubleInjection objects have met their


### PR DESCRIPTION
Silences a `method redefined; discarding old any_instance_of` warning when using RR or running its specs under Ruby 1.8.7.
