### PR TITLE
Rename utility methods #reset and #verify to reset_rr and verify_rr to avoid clashes with other methods in Cucumber's World namespace

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,2 +1,2 @@
-rvm 1.9.2-p180@rr
+rvm 1.9.2@rr
 #rvm ree@rr

--- a/lib/rr/adapters/rr_methods.rb
+++ b/lib/rr/adapters/rr_methods.rb
@@ -36,12 +36,12 @@ module RR
 
       # Verifies all the DoubleInjection objects have met their
       # TimesCalledExpectations.
-      def verify
+      def verify_rr
         RR::Space.instance.verify_doubles
       end
 
       # Resets the registered Doubles and ordered Doubles
-      def reset
+      def reset_rr
         RR::Space.instance.reset
       end
 

--- a/spec/rr/adapters/rr_methods_space_spec.rb
+++ b/spec/rr/adapters/rr_methods_space_spec.rb
@@ -12,13 +12,13 @@ module RR
         @method_name = :foobar
       end
 
-      describe "#verify" do
-        it "aliases #rr_verify" do
-          RRMethods.instance_method("verify").should == RRMethods.instance_method("rr_verify")
+      describe "#verify_rr" do
+        it "aliases #rr_verify_rr" do
+          RRMethods.instance_method("verify_rr").should == RRMethods.instance_method("rr_verify_rr")
         end
       end
 
-      describe "#rr_verify" do
+      describe "#rr_verify_rr" do
         it "verifies and deletes the double_injections" do
           double_1 = ::RR::Injections::DoubleInjection.find_or_create_by_subject(subject_1, method_name)
           double_1_verify_calls = 0
@@ -46,7 +46,7 @@ module RR
             end
           end
 
-          rr_verify
+          rr_verify_rr
           double_1_verify_calls.should == 1
           double_2_verify_calls.should == 1
           double_1_reset_calls.should == 1
@@ -54,20 +54,20 @@ module RR
         end
       end
 
-      describe "#reset" do
-        it "aliases #rr_reset" do
-          RRMethods.instance_method("reset").should == RRMethods.instance_method("rr_reset")
+      describe "#reset_rr" do
+        it "aliases #rr_reset_rr" do
+          RRMethods.instance_method("reset_rr").should == RRMethods.instance_method("rr_reset_rr")
         end
       end
 
-      describe "#rr_reset" do
+      describe "#rr_reset_rr" do
         it "removes the ordered doubles" do
           mock(subject_1).foobar1.ordered
           mock(subject_2).foobar2.ordered
 
           ::RR::Injections::DoubleInjection.instances.should_not be_empty
 
-          rr_reset
+          rr_reset_rr
           ::RR::Injections::DoubleInjection.instances
           ::RR::Injections::DoubleInjection.instances.should be_empty
         end
@@ -88,7 +88,7 @@ module RR
             end
           end
 
-          rr_reset
+          rr_reset_rr
           double_1_reset_calls.should == 1
           double_2_reset_calls.should == 1
         end


### PR DESCRIPTION
e.g. Gherkin::Formatter::AnsiEscapes#reset

Specifically I ran into an exception from this line in cucumber's lib/cucumber/rb_support/rb_world.rb:         

``` ruby
STDERR.puts failed + "WARNING: Using 'Given/When/Then' in step definitions is deprecated, use 'step' to call other steps instead:" + caller[0] + reset
```

Specs pass. Seems to me that these 2 methods would be better off properly namespaces, and the Gherkin AnsiEscapes methods should do the same. Thoughts?
