### PR TITLE
Respond_to? behavior changing on calls to method_missing

### DIFF
--- a/spec/rr/injections/method_missing_injection_spec.rb
+++ b/spec/rr/injections/method_missing_injection_spec.rb
@@ -1,0 +1,17 @@
+require File.expand_path("#{File.dirname(__FILE__)}/../../spec_helper")
+
+
+describe RR::Injections::MethodMissingInjection do
+
+  context "#bind_method" do
+    it 'should not change the behavior of respond_to?' do
+      o = Object.new
+      stub(o).some_method { true }
+      o.respond_to?(:another_method).should be_false
+      lambda { o.another_method }.should raise_error(NoMethodError)
+      o.respond_to?(:another_method).should be_false
+    end
+
+  end
+
+end


### PR DESCRIPTION
Yo btakita,

First off, thanks for rr!

We discovered respond_to? changes behavior when method_missing is called on a mocked object. We only added a failing test case, because we’re still trying to figure out the best way to fix it. We thought you’d have a much better idea.

Incidentally, this is the base cause of issue #44.

Thanks!
