### PR TITLE
Rspec2 gemspec fix

### DIFF
--- a/rr.gemspec
+++ b/rr.gemspec
@@ -99,7 +99,6 @@ Gem::Specification.new do |s|
      "lib/rr/wildcard_matchers/range.rb",
      "lib/rr/wildcard_matchers/regexp.rb",
      "lib/rr/wildcard_matchers/satisfy.rb",
-     "scratch.rb",
      "spec/api/any_instance_of/all_instances_of_spec.rb",
      "spec/api/any_instance_of/any_instance_of_spec.rb",
      "spec/api/dont_allow/dont_allow_after_stub_spec.rb",


### PR DESCRIPTION
After specifying branch to use in my Gemfile like:

```
gem 'rr', :git => 'git://github.com/btakita/rr.git', :branch => 'rspec2'
```

I got the following after running bundle install:

```
rr at /Users/damselem/.rvm/gems/ruby-1.9.3-p0@cra/bundler/gems/rr-91f638cee364 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was: ["scratch.rb"] are not files
```
